### PR TITLE
[FIX] Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js


### PR DESCRIPTION
#### What's this do?

Tell Travis CI to use Node.js.

#### Why are we doing this? (w/ JIRA link if applicable)

Travis CI uses Ruby by default. This project is a Node.js project.