### PR TITLE
Connect Travis CI to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: node_js
+deploy:
+  provider: npm
+  email: scottiet123@gmail.com
+  api_key:
+    secure: SI8xfATbxesHMuc2N42Kft5aaq8EdLr1mVLeLIEgOd29vnbMFhLouzCB6j1sr7FD4E5wRW18HJddFu2bCXHzchTRmB5tcKr5wTPufTv4P5mD4CTF6wJTV/8GSz9SvrAoe7v38aJ38oRzKBbVw6kYTjsEwh5cYZCmGhTUKCTxKBtwn5Qhu/isRCzJPitfRNEJTif7HyhJKnsT61W7co2bcxP7iVRjiSoL568F9vmB+vX/xRInn3hXTXitJinXmsf25n9lXdEV9VuD/cgnux0QPwYPFTmq47/HBOQsWrTKzLG/trOnY/rj8+S9vjoY2I1H0Fq9lHBeba3bXHAuYgitPHhrseAfpmfl6sdNDsik6l+Q7UQ0HlgW4Beqdu2ZdOLa0hMc2u3YeN6742gaHgwnJh+u26ti+b6RaOyf6MnN1EH+3jt59vNfZBpVMdilZc6YZ6nnUTl7bV48iBpp22hYIT+CIl9uAu43qN1GED2kKXk2KjnNhTPPENTnoJT37Yodk0fQucvaGCResxoyXOfFeeOMDpRi2gSv3aBeaVCbIMtMi5M8vc+/+PuDxxLSz0jZtE58EraGV4CwL7i8E1bG0ptD2UBVwUVtA9zSqNtQxGA8oCZKVLp2OO84jYH+TSp+SZATyWxh6xPaNSkRbg+yOpXYsuzK8xEK2MSPfdO4iVU=
+  on:
+    tags: true
+    repo: scotttesler/migurt


### PR DESCRIPTION
Travis CI will deploy new tags to npm.

**Resources:**
https://docs.travis-ci.com/user/deployment/npm/