### PR TITLE
FIX Use same exact time since epoch for up and down files

### DIFF
--- a/src/interactors/CreateFiles.js
+++ b/src/interactors/CreateFiles.js
@@ -7,8 +7,9 @@ class CreateFiles {
   static async perform({ dirDown, dirUp, name }) {
     CreateDirectoriesIfNotExists.perform({ dirs: [dirUp, dirDown] });
 
-    const filenameUp = `${dirUp}/${Date.now()}_${name}.sql`;
-    const filenameDown = `${dirDown}/${Date.now()}_${name}.sql`;
+    const now = Date.now();
+    const filenameUp = `${dirUp}/${now}_${name}.sql`;
+    const filenameDown = `${dirDown}/${now}_${name}.sql`;
 
     fs.writeFileSync(filenameUp, "");
     Log.success(`Created file ${filenameUp}`);


### PR DESCRIPTION
Currently, different time since epochs may be created for `up` and `down` filenames.